### PR TITLE
BinarySearchTree Node Removal problem solving

### DIFF
--- a/src/main/java/com/company/sample/tree/Node.java
+++ b/src/main/java/com/company/sample/tree/Node.java
@@ -6,19 +6,27 @@ import java.util.List;
 
 public class Node {
     boolean isRoot = false;
+
     public Node(String value) {
         this.value = value;
     }
-    public int depth= 0;
+
+    public int numericValue;
+
+    public int depth = 0;
 
     public List<Node> children = new LinkedList<>();
     public String value;
+
+    public Node(int numericValue) {
+        this.numericValue = numericValue;
+    }
 
     public void addChild(Node child) {
         children.add(child);
     }
 
-    public void addChildren(Node ...values) {
+    public void addChildren(Node... values) {
         children.addAll(Arrays.asList(values));
     }
 }

--- a/src/main/java/com/company/sample/tree/Node.java
+++ b/src/main/java/com/company/sample/tree/Node.java
@@ -5,7 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class Node {
-    boolean isRoot = false;
+    public boolean isRoot = false;
 
     public Node(String value) {
         this.value = value;

--- a/src/main/java/com/company/sample/tree/Node.java
+++ b/src/main/java/com/company/sample/tree/Node.java
@@ -16,6 +16,8 @@ public class Node {
     public int depth = 0;
 
     public List<Node> children = new LinkedList<>();
+    public Node leftChild;
+    public Node rightChild;
     public String value;
 
     public Node(int numericValue) {

--- a/src/main/java/com/company/sample/tree/btree/BinaryTreeNodeRemoval.java
+++ b/src/main/java/com/company/sample/tree/btree/BinaryTreeNodeRemoval.java
@@ -1,4 +1,23 @@
 package com.company.sample.tree.btree;
 
+import com.company.sample.tree.Node;
+
 public class BinaryTreeNodeRemoval {
+
+    public Node removeRootNodeOfBSearchTre(Node binarySearchTree) {
+        Node prevLeft = binarySearchTree.leftChild;
+        binarySearchTree.numericValue = prevLeft.numericValue;
+        binarySearchTree.rightChild = mergeBTree(binarySearchTree.rightChild, prevLeft.rightChild);
+        binarySearchTree.leftChild = prevLeft.leftChild;
+        return binarySearchTree;
+    }
+
+    public Node mergeBTree(Node bigger, Node smaller) {
+        if (bigger.leftChild == null) {
+            bigger.leftChild = smaller;
+            return bigger;
+        }
+        bigger.leftChild = mergeBTree(bigger.leftChild, smaller);
+        return bigger;
+    }
 }

--- a/src/main/java/com/company/sample/tree/btree/BinaryTreeNodeRemoval.java
+++ b/src/main/java/com/company/sample/tree/btree/BinaryTreeNodeRemoval.java
@@ -1,0 +1,4 @@
+package com.company.sample.tree.btree;
+
+public class BinaryTreeNodeRemoval {
+}

--- a/src/test/java/com/company/sample/tree/btree/BinaryTreeNodeRemovalTest.java
+++ b/src/test/java/com/company/sample/tree/btree/BinaryTreeNodeRemovalTest.java
@@ -1,0 +1,7 @@
+package com.company.sample.tree.btree;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BinaryTreeNodeRemovalTest {
+
+}

--- a/src/test/java/com/company/sample/tree/btree/BinaryTreeNodeRemovalTest.java
+++ b/src/test/java/com/company/sample/tree/btree/BinaryTreeNodeRemovalTest.java
@@ -58,7 +58,7 @@ class BinaryTreeNodeRemovalTest {
     }
 
     @Test
-    public void testVerifyBtree() {
+    public void testVerifyBtree_whenValidBinarySearchTreeIsGiven_thenReturningTrue() {
         // Given
 
         // When

--- a/src/test/java/com/company/sample/tree/btree/BinaryTreeNodeRemovalTest.java
+++ b/src/test/java/com/company/sample/tree/btree/BinaryTreeNodeRemovalTest.java
@@ -1,9 +1,15 @@
 package com.company.sample.tree.btree;
 
 import com.company.sample.tree.Node;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class BinaryTreeNodeRemovalTest {
+    private static BinaryTreeNodeRemoval binaryTreeNodeRemoval = new BinaryTreeNodeRemoval();
     private static Node testTree;
 
 
@@ -14,8 +20,8 @@ class BinaryTreeNodeRemovalTest {
     //           55    82
     //          /  \
     //        49   69
-    @Before
-    public void buildFullBinarySearchTree() {
+    @BeforeAll
+    public static void buildFullBinarySearchTree() {
         //Root level
         Node root = new Node(31);
         root.isRoot = true;
@@ -34,6 +40,59 @@ class BinaryTreeNodeRemovalTest {
         rightChildOfRoot.rightChild = rightOfRightRootChild;
 
         //4th
-        Node leftChildOfRightChildOfRightRootChild = new Node(69);
+        Node leftChildOfLeftChildOfRightRootChild = new Node(49);
+        Node rightChildOfLeftChildOfRightRootChild = new Node(69);
+        leftOfRightRootChild.leftChild = leftChildOfLeftChildOfRightRootChild;
+        leftOfRightRootChild.rightChild = rightChildOfLeftChildOfRightRootChild;
+    }
+
+    @Test
+    public void removeRightChildNode_thenReturnedTreeShouldBeBinarySearchTree() {
+        // Given
+
+        // When
+        Node after = binaryTreeNodeRemoval.removeRightChildNode(testTree);
+
+        // Then
+    }
+
+    @Test
+    public void testVerifyBtree() {
+        // Given
+
+        // When
+        boolean validBtree = verifyBtree(testTree);
+
+        // Then
+        assertThat(validBtree).isTrue();
+    }
+
+    private boolean verifyBtree(Node tree) {
+        LinkedList<Node> ascending = traverseInOrder(tree);
+        Node prev = null;
+
+        for (Node node : ascending) {
+            System.out.println(node.numericValue);
+            if (prev == null) {
+                prev = node;
+            } else {
+                if (node.numericValue < prev.numericValue) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private LinkedList<Node> traverseInOrder(Node parent) {
+        LinkedList<Node> sorted = new LinkedList<>();
+        if (parent.leftChild != null) {
+            sorted.addAll(traverseInOrder(parent.leftChild));
+        }
+        sorted.add(parent);
+        if (parent.rightChild != null) {
+            sorted.addAll(traverseInOrder(parent.rightChild));
+        }
+        return sorted;
     }
 }

--- a/src/test/java/com/company/sample/tree/btree/BinaryTreeNodeRemovalTest.java
+++ b/src/test/java/com/company/sample/tree/btree/BinaryTreeNodeRemovalTest.java
@@ -1,7 +1,14 @@
 package com.company.sample.tree.btree;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.company.sample.tree.Node;
+import org.junit.Before;
 
 class BinaryTreeNodeRemovalTest {
 
+    @Before
+    public void buildFullBinarySearchTree() {
+        //Root level
+        Node root = new Node(31);
+        root.isRoot = true;
+    }
 }

--- a/src/test/java/com/company/sample/tree/btree/BinaryTreeNodeRemovalTest.java
+++ b/src/test/java/com/company/sample/tree/btree/BinaryTreeNodeRemovalTest.java
@@ -51,9 +51,10 @@ class BinaryTreeNodeRemovalTest {
         // Given
 
         // When
-        Node after = binaryTreeNodeRemoval.removeRightChildNode(testTree);
+        testTree.rightChild = binaryTreeNodeRemoval.removeRootNodeOfBSearchTre(testTree.rightChild);
 
         // Then
+        assertThat(verifyBtree(testTree)).isTrue();
     }
 
     @Test

--- a/src/test/java/com/company/sample/tree/btree/BinaryTreeNodeRemovalTest.java
+++ b/src/test/java/com/company/sample/tree/btree/BinaryTreeNodeRemovalTest.java
@@ -4,11 +4,36 @@ import com.company.sample.tree.Node;
 import org.junit.Before;
 
 class BinaryTreeNodeRemovalTest {
+    private static Node testTree;
 
+
+    //           31
+    //          /   \
+    //         17   72
+    //             /   \
+    //           55    82
+    //          /  \
+    //        49   69
     @Before
     public void buildFullBinarySearchTree() {
         //Root level
         Node root = new Node(31);
         root.isRoot = true;
+        testTree = root;
+
+        //2nd
+        Node leftChildOfRoot = new Node(17);
+        Node rightChildOfRoot = new Node(72);
+        root.leftChild = leftChildOfRoot;
+        root.rightChild = rightChildOfRoot;
+
+        //3rd
+        Node leftOfRightRootChild = new Node(55);
+        Node rightOfRightRootChild = new Node(82);
+        rightChildOfRoot.leftChild = leftOfRightRootChild;
+        rightChildOfRoot.rightChild = rightOfRightRootChild;
+
+        //4th
+        Node leftChildOfRightChildOfRightRootChild = new Node(69);
     }
 }


### PR DESCRIPTION
- All the values of elements in the left (right) sub-tree should be smaller(bigger) than the root.

After removing the parent node and **the left child node** is the next parent, **the right node and its children of the new parent node** should be moved into **the right subtree of the parent** and **the deepest and the very left side**.